### PR TITLE
Key backup: add `PUT /room_keys/version/{version}`

### DIFF
--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -179,17 +179,16 @@ Error codes:
 
 ##### `PUT /room_keys/version/{version}`
 
-Update information about the given version, or the current version if `{version}`
-is omitted. Only `auth_data` can be updated.
+Update information about the given version. Only `auth_data` can be updated.
 
 Body parameters:
 
-- `algorithm` (string): Optional. Must be the same as in the body parameters for `GET
+- `algorithm` (string): Required. Must be the same as in the body parameters for `GET
  /room_keys/version`.
 - `auth_data` (object): Required. algorithm-dependent data.  For
   `m.megolm_backup.v1.curve25519-aes-sha2`, see below for the definition of
   this property.
-- `version` (string): Optional. The backup version. Must be the same as the query parameter or must be the current version.
+- `version` (string): Required. The backup version. Must be the same as the query parameter or must be the current version.
 
 Example:
 

--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -194,6 +194,7 @@ Example:
 
 ```javascript
 {
+  "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
   "auth_data": {
     "public_key": "abcdefg",
     "signatures": {
@@ -202,7 +203,8 @@ Example:
         "ed25519:anotherthing": "abcdef"
       }
     }
-  }
+  },
+  "version": "42"
 }
 ```
 

--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -177,6 +177,42 @@ Error codes:
 
 - `M_NOT_FOUND`: No backup version has been created.
 
+##### `PUT /room_keys/version/{version}`
+
+Update information about the given version, or the current version if `{version}`
+is omitted. Only `auth_data` can be updated.
+
+Body parameters:
+
+- `algorithm` (string): Optional. Must be the same as in the body parameters for `GET
+ /room_keys/version`.
+- `auth_data` (object): Required. algorithm-dependent data.  For
+  `m.megolm_backup.v1.curve25519-aes-sha2`, see below for the definition of
+  this property.
+- `version` (string): Optional. The backup version. Must be the same as the query parameter or must be the current version.
+
+Example:
+
+```javascript
+{
+  "auth_data": {
+    "public_key": "abcdefg",
+    "signatures": {
+      "something": {
+        "ed25519:something": "hijklmnop"
+        "ed25519:anotherthing": "abcdef"
+      }
+    }
+  }
+}
+```
+
+On success, returns the empty JSON object.
+
+Error codes:
+
+- `M_NOT_FOUND`: No backup version found.
+
 #### Storing keys
 
 ##### `PUT /room_keys/keys/${roomId}/${sessionId}?version=$v`


### PR DESCRIPTION
 to allow matrix clients to add signatures to an existing backup or update any information in the `auth_data` field.