### PR TITLE
Key backup: Expose number of stored keys and a hash of them

### DIFF
--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -172,6 +172,7 @@ On success, returns a JSON object with keys:
 - `auth_data` (object): Required. Same as in the body parameters for
   `POST /room_keys/version`.
 - `version` (string): Required. The backup version.
+- `count` (number): Required. The number of keys stored in the backup.
 
 Error codes:
 

--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -172,7 +172,10 @@ On success, returns a JSON object with keys:
 - `auth_data` (object): Required. Same as in the body parameters for
   `POST /room_keys/version`.
 - `version` (string): Required. The backup version.
-- `hash` (string): Required. A hash value representing stored keys.
+- `hash` (string): Required. The hash value which is an opaque string 
+ representing stored keys in the backup. Client can compare it with the `hash`
+ value they received in the response of their last key storage request.
+ If not equal, another matrix client pushed new keys to the backup.
 - `count` (number): Required. The number of keys stored in the backup.
 
 Error codes:
@@ -206,7 +209,8 @@ Body parameters:
 
 On success, returns a JSON object with keys:
 
-- `hash` (string): Required. The new hash value representing stored keys.
+- `hash` (string): Required. The new hash value representing stored keys. See
+`GET /room_keys/version/{version}` for more details.
 
 Error codes:
 

--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -172,6 +172,7 @@ On success, returns a JSON object with keys:
 - `auth_data` (object): Required. Same as in the body parameters for
   `POST /room_keys/version`.
 - `version` (string): Required. The backup version.
+- `hash` (string): Required. A hash value representing stored keys.
 - `count` (number): Required. The number of keys stored in the backup.
 
 Error codes:
@@ -203,7 +204,9 @@ Body parameters:
   `m.megolm_backup.v1.curve25519-aes-sha2`, see below for the definition of
   this property.
 
-On success, returns the empty JSON object.
+On success, returns a JSON object with keys:
+
+- `hash` (string): Required. The new hash value representing stored keys.
 
 Error codes:
 
@@ -230,8 +233,11 @@ Example:
 Result:
 
 ```javascript
-{}
+{
+  "hash": "abcdefghi"
+}
 ```
+
 ##### `PUT /room_keys/keys/${roomId}?version=$v`
 
 Store several keys for the given room, using the given backup version.
@@ -271,8 +277,11 @@ Example:
 Result:
 
 ```javascript
-{}
+{
+  "hash": "abcdefghi"
+}
 ```
+
 ##### `PUT /room_keys/keys?version=$v`
 
 Store several keys, using the given backup version.
@@ -316,7 +325,9 @@ Example:
 Result:
 
 ```javascript
-{}
+{
+  "hash": "abcdefghi"
+}
 ```
 
 #### Retrieving keys

--- a/proposals/1219-storing-megolm-keys-serverside.md
+++ b/proposals/1219-storing-megolm-keys-serverside.md
@@ -211,6 +211,7 @@ On success, returns a JSON object with keys:
 
 - `hash` (string): Required. The new hash value representing stored keys. See
 `GET /room_keys/version/{version}` for more details.
+- `count` (number): Required. The new count of keys stored in the backup.
 
 Error codes:
 
@@ -238,7 +239,8 @@ Result:
 
 ```javascript
 {
-  "hash": "abcdefghi"
+  "hash": "abcdefghi",
+  "count": 10
 }
 ```
 
@@ -282,7 +284,8 @@ Result:
 
 ```javascript
 {
-  "hash": "abcdefghi"
+  "hash": "abcdefghi",
+  "count": 10
 }
 ```
 
@@ -330,7 +333,8 @@ Result:
 
 ```javascript
 {
-  "hash": "abcdefghi"
+  "hash": "abcdefghi",
+  "count": 10
 }
 ```
 


### PR DESCRIPTION
The number is a useful information.

The hash allows a matrix client A to check it is synchronised with the backup.
If not, that means that another client B has pushed keys client A does not have locally. Client A should then propose to the end user to retrieve  keys from the backup.